### PR TITLE
Widen Rails dependency to support 8.x

### DIFF
--- a/evolution.gemspec
+++ b/evolution.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 4.0", "< 7.1"
+  s.add_dependency "rails", ">= 4.0", "< 9"
   s.add_runtime_dependency "acts_as_dag", ">= 2"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
## Summary

The existing pin of `rails >= 4.0, < 7.1` blocked hosts from upgrading to Rails 7.1+ via the connect_engine fleet. Widen the upper bound to `< 9` (covering 7.x and 8.x). No code changes were needed — the gem operates on simple ActiveRecord callbacks that haven't been disturbed by Rails 7/8.

## Test plan

- [ ] `bundle install` succeeds in a host on Rails 8 (verified locally in `services_connect-connect-engine-2` and `permits_connect-connect-engine-2`)
- [ ] Existing evolution test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)